### PR TITLE
Fixed Delete `␍`eslintprettier/prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -54,6 +54,7 @@
     }
   },
   "rules": {
+    "prettier/prettier": ["error", { "endOfLine": "auto" }],
     "import/extensions": "off",
     "react/prop-types": "off",
     "no-plusplus": "off",


### PR DESCRIPTION
<!--

## Checklist

Please make all of these are true before submitting a pull request.

- My PR branch was based on the `dev` branch
- I am submitting this PR against the `dev` branch
- I wrote or updated any tests related to my changes
- I ran `npm run cq` to format and test my code

-->

## Type of Pull Request

- [x] Bug fix
- [ ] Enhancement

Related Issue #s or links (if any): 
issue #15 
## Description of Changes
Many editors let you change between CRLF and LF line-ending modes. I have added the auto mode in ESLint File. 
In `.eslintrc.json` file, I have configured rules option by adding the following configuration.
`prettier/prettier": ["error", { "endOfLine": "auto" }]`
![image](https://user-images.githubusercontent.com/76687985/193640074-f60c4dc1-a160-46ce-b7e6-c40bb7d94497.png)

