### PR TITLE
Fix: URL Encode tool doesn't catch input error

### DIFF
--- a/__TESTS__/url-encode.spec.tsx
+++ b/__TESTS__/url-encode.spec.tsx
@@ -30,4 +30,19 @@ describe('URLEncodeDecode', () => {
       );
     });
   });
+  it('should detect invalid encoded text', () => {
+    render(<URLEncodeDecode />);
+
+    const encodedOutput = screen.getByLabelText(
+      'Encoded',
+    ) as HTMLInputElement;
+    userEvent
+      .type(encodedOutput, 'https%3A%2F%2Fexample.com%')
+      .then(() => {
+        const errorMessage = screen.getByText(
+          'Error: Invalid URL Encoded Text',
+        );
+        expect(errorMessage).toBeInTheDocument();
+      });
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "next-mui-playground",
+  "name": "developertools.tech",
   "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "next-mui-playground",
+      "name": "developertools.tech",
       "version": "0.1.0",
       "dependencies": {
         "@emotion/cache": "^11.10.3",

--- a/pages/url-encode.tsx
+++ b/pages/url-encode.tsx
@@ -4,6 +4,7 @@ import ContentPasteGoIcon from '@mui/icons-material/ContentPasteGo';
 import { Typography } from '@mui/material';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import { red } from '@mui/material/colors';
 import TextField from '@mui/material/TextField';
 import React, { useState } from 'react';
 
@@ -23,6 +24,7 @@ export default function URLEncodeDecode() {
     key: 'urlDecode',
     defaultValue: '',
   });
+  const [decodeError, setDecodeError] = useState<boolean>(false);
 
   const [toastOpen, setToastOpen] = useState<boolean>(false);
   const [toastMessage, setToastMessage] = useState<string>('');
@@ -126,16 +128,32 @@ export default function URLEncodeDecode() {
             label='Encoded'
             value={encoded}
             onChange={(e) => {
-              setDecoded(decodeURIComponent(e.target.value));
               setEncoded(e.target.value);
+
+              try {
+                setDecoded(decodeURIComponent(e.target.value));
+                setDecodeError(false);
+              } catch {
+                setDecodeError(true);
+              }
             }}
             multiline
           />
           <Box
             display='flex'
+            alignItems='center'
             flexWrap='wrap'
             justifyContent='end'
           >
+            {decodeError && (
+              <Typography
+                marginRight='auto'
+                variant='caption'
+                color={red[500]}
+              >
+                Error: Invalid URL Encoded Text
+              </Typography>
+            )}
             <Button
               disabled={!encoded}
               startIcon={<ClearIcon />}

--- a/pages/url-encode.tsx
+++ b/pages/url-encode.tsx
@@ -24,7 +24,10 @@ export default function URLEncodeDecode() {
     key: 'urlDecode',
     defaultValue: '',
   });
-  const [decodeError, setDecodeError] = useState<boolean>(false);
+  const [decodeError, setDecodeError] = useLocalState<boolean>({
+    key: 'urlDecodeError',
+    defaultValue: false,
+  });
 
   const [toastOpen, setToastOpen] = useState<boolean>(false);
   const [toastMessage, setToastMessage] = useState<string>('');

--- a/pages/url-encode.tsx
+++ b/pages/url-encode.tsx
@@ -148,15 +148,6 @@ export default function URLEncodeDecode() {
             flexWrap='wrap'
             justifyContent='end'
           >
-            {decodeError && (
-              <Typography
-                marginRight='auto'
-                variant='caption'
-                color={red[500]}
-              >
-                Error: Invalid URL Encoded Text
-              </Typography>
-            )}
             <Button
               disabled={!encoded}
               startIcon={<ClearIcon />}
@@ -194,6 +185,15 @@ export default function URLEncodeDecode() {
               </Button>
             )}
           </Box>
+          {decodeError && (
+            <Typography
+              textAlign='right'
+              variant='caption'
+              color={red[500]}
+            >
+              Error: Invalid URL Encoded Text
+            </Typography>
+          )}
         </Box>
       </Box>
       <Toast


### PR DESCRIPTION
## Type of Pull Request

- [X] Bug fix
- [ ] Enhancement

Related Issue #s or links (if any): 
Closes #30 

## Description of Changes
Adds a error handler on URL encode tool:


https://user-images.githubusercontent.com/26071571/194366177-ca86eee7-b147-4908-a1b4-0fe71d608820.mp4

